### PR TITLE
fixed bug caused by changed function name in versionstring

### DIFF
--- a/scripts/multilocus_prevfreq_naive/README.md
+++ b/scripts/multilocus_prevfreq_naive/README.md
@@ -23,7 +23,7 @@ appears, and depends on the number of heterozygous loci:
   be present in the sample. From the relative read counts at this heterozygous locus we can obtain a
   rough estimate of the within-sample proportions of each genotype.
 - If there are **two or more heterozygous loci** then we cannot unambiguously state which genotypes
-  are present. Doing so would require running more complex methods that attempt to phase genotypes.
+  are present. Doing so would require running more advanced methods that attempt to phase genotypes.
 
 We can use these rules to obtain all known phased genotypes from the raw data.
 For example, imagine we have the following two samples, defined in
@@ -61,7 +61,7 @@ the following steps:
 
 1. Convert input data into variant string format
 2. Extract all unambiguous phased genotypes from the data
-3. Compare all phased genotypes against the data to estimate prevalence and frequency
+3. Compare all phased genotypes back against the data to estimate prevalence and frequency
 
 Genotype frequency in this case is obtained as the average of the within-sample
 genotype frequencies (WSGF) over all samples. This has the advantage of being an
@@ -71,7 +71,7 @@ without requiring a known complexity of infection for each sample.
 
 ## Script Usage
 
-The `multilocus_prevfreq_naive.R` script contains all the requisite functions to
+The `multilocus_prevfreq_naive.R` script contains all the functions needed to
 read in the data, calculate prevalence and frequency, and write results to file.
 
 An example of usage, executed from the root of this repo, would be:

--- a/scripts/multilocus_prevfreq_naive/multilocus_prevfreq_naive.R
+++ b/scripts/multilocus_prevfreq_naive/multilocus_prevfreq_naive.R
@@ -7,8 +7,8 @@ library(validate)
 # install a specific version of variantstring package (this is in development so
 # may not always be backwards-compatible)
 if (!requireNamespace("variantstring", quietly = TRUE) ||
-    packageVersion("variantstring") != "1.7.0") {
-  remotes::install_github("mrc-ide/variantstring@1.7.0")
+    packageVersion("variantstring") != "1.8.0") {
+  remotes::install_github("mrc-ide/variantstring@1.8.0")
 }
 library(variantstring) 
 
@@ -106,46 +106,6 @@ aa_table_to_variant <- function(input_path) {
 }
 
 # ----------------------------------------------------------------------
-#' Get all component genotypes from a vector of variant strings
-#'
-#' @description
-#' Takes a vector of variant strings and extracts all multi-locus genotypes that
-#' can be unambiguously identified within these samples. Return these in variant
-#' string format, which will contain no heterozygous loci.
-#'
-#' @param variant_strings a vector of variant strings.
-#' 
-#' @return vector of component variant strings.
-
-get_component_variants <- function(variant_strings) {
-  
-  # Check input arguments
-  check_variant_string(variant_strings)
-  
-  # get all unique positions
-  pos_unique <- position_from_variant_string(variant_strings) |>
-    unique()
-  
-  # get all variant strings at all positions of interest
-  vs_allpos <- mapply(function(x) {
-    subset_position(position_string = x,
-                    variant_strings = variant_strings) |>
-      na.omit() |>
-      unique()
-  }, pos_unique, SIMPLIFY = FALSE) |>
-    unlist() |>
-    unique()
-  
-  # get targets as all component genotypes
-  targets <- get_consistent_variants(vs_allpos) |>
-    unlist() |>
-    na.omit() |>
-    unique()
-  
-  return(targets)
-}
-
-# ----------------------------------------------------------------------
 #' Get prevalence of a set of variants
 #'
 #' @description
@@ -222,7 +182,11 @@ args <- parse_args(OptionParser(option_list = opts))
 variant_strings <- aa_table_to_variant(input_path = args$input_path)
 
 # get the component genotypes that make up these samples
-component_variants <- get_component_variants(variant_strings = variant_strings)
+component_variants <- variantstring::get_component_variants(x = variant_strings) |>
+  unlist() |>
+  na.omit() |>
+  as.vector() |>
+  unique()
 
 # calculate prevalence
 df_prev <- calculate_variant_prevalence(target_variants = component_variants,


### PR DESCRIPTION
Fixed a bug caused by function name changes in latest version of variantstring package.

The function `get_component_variants()` is now internal to variantstring, meaning it was creating an infinite recursion when the same name was used in the wrapper script. This is now fixed, with the added advantage of a slightly more streamlined workflow.

