### PR TITLE
Add option to make Dcifer wrapper more verbose

### DIFF
--- a/scripts/dcifer_wrapper/dcifer_wrapper.R
+++ b/scripts/dcifer_wrapper/dcifer_wrapper.R
@@ -66,6 +66,12 @@ opts <- list(
     help = "Random number seed. Optional."
   ), 
   make_option(
+    c("-v", "--verbose"), 
+    action = "store_true", 
+    default = FALSE, 
+    help = "Print detailed process output"
+  ), 
+  make_option(
     "--btwn_host_rel_output", 
     help = str_c(
       "Path of TSV file to contain relatedness results, with the columns: ", 
@@ -372,7 +378,11 @@ run_dcifer <- function(
     }
     
     if (is.null(getDefaultCluster())) {
-        cl <- makeCluster(total_cores)
+        if (arg$verbose) {
+          cl <- makeCluster(total_cores, outfile = "")
+        } else {
+          cl <- makeCluster(total_cores)
+        }
         setDefaultCluster(cl)
         registerDoParallel(cl)
     } else {


### PR DESCRIPTION
## Pull Request for PGEcore

Thank you for your contribution to PGEcore!✨

### Description of changes
Add -v flag to Dcifer wrapper that tells makeCluster() to send more detailed process output to standard output. This is sometimes useful for debugging.

### Pull Request Checklist

- [x] I have provided a description and detailed information about the changes made
- [x] I have followed the [PGEcore Code Guidelines](https://github.com/PlasmoGenEpi/PGEcore?tab=readme-ov-file#code-guidelines)
- [x] I have followed the [PGEcore how to contribute instructions](https://github.com/PlasmoGenEpi/PGEcore?tab=readme-ov-file#how-to-contribute) and I am merging into the `develop` branch
- [x] Documentation is updated, if necessary
- [x] Relevant issues are linked, if applicable
