### PR TITLE
Specify col_types for allele table input

### DIFF
--- a/scripts/estimate_coi_naive/estimate_coi_naive.R
+++ b/scripts/estimate_coi_naive/estimate_coi_naive.R
@@ -96,7 +96,11 @@ run_estimate_coi_naive <- function(input_path,
   stopifnot((quantile_threshold >= 0) & (quantile_threshold <= 1))
   
   # Read allele calls from file
-  df_alleles <- read.table(file = input_path, header = TRUE)
+  df_alleles <- read_tsv(
+    input_path, 
+    col_types = cols(.default = col_character(), read_count = col_integer()), 
+    progress = FALSE
+  )
   
   # Validate input format
   rules <- validate::validator(is.character(specimen_id),


### PR DESCRIPTION
## Pull Request for PGEcore

Thank you for your contribution to PGEcore!✨

### Description of changes
Switch to using read_tsv and specify column types in estimate_coi_naive.R. This is helpful if R will guess column types wrong in the input table (e.g., if all specimen_ids are numeric).

### Pull Request Checklist

- [x] I have provided a description and detailed information about the changes made
- [x] I have followed the [PGEcore Code Guidelines](https://github.com/PlasmoGenEpi/PGEcore?tab=readme-ov-file#code-guidelines)
- [x] I have followed the [PGEcore how to contribute instructions](https://github.com/PlasmoGenEpi/PGEcore?tab=readme-ov-file#how-to-contribute) and I am merging into the `develop` branch
- [x] Documentation is updated, if necessary
- [x] Relevant issues are linked, if applicable
