### PR TITLE
Fix indexing bug that excludes sample pairs from Dcifer

### DIFF
--- a/scripts/dcifer_wrapper/dcifer_wrapper.R
+++ b/scripts/dcifer_wrapper/dcifer_wrapper.R
@@ -395,8 +395,11 @@ run_dcifer <- function(
             .packages = c("dcifer", "foreach", "iterators")
           ) %dopar% {
         total_pairs <- nrow(sample_pairs)
-        begin_idx <- ((i - 1) * total_pairs / total_cores) + 1
-        end_idx <- (i * total_pairs / total_cores)
+        # Use floor to avoid off-by-one error when these equations 
+        # don't yield a whole number. All pairs will still be included 
+        # because end_idx will be a whole number when i = total_cores.
+        begin_idx <- floor(((i - 1) * total_pairs / total_cores) + 1)
+        end_idx <- floor((i * total_pairs / total_cores))
         pairs <- sample_pairs[begin_idx:end_idx, ]
         out <- foreach(pair = iter(pairs, by = "row"), .combine = rbind) %do% {
             ix <- pair$Var1


### PR DESCRIPTION
## Pull Request for PGEcore

Thank you for your contribution to PGEcore!✨

### Description of changes
The calculation of the start and end indices (begin_idx and end_idx) of the sample pairs to be processed by each thread in run_dcifer() had a bug. If the calculation did not yield an integer, the result would be implicitly rounded to an integer when used for indexing, which could lead to a situation where, e.g., end_idx for thread 1 rounded down, begin_idx for thread 2 rounded up, and an index fell between the two, leading to that pair's exclusion from the calculation.

To fix this, floor() is called on the result of each calculation (see code for details).

### Pull Request Checklist

- [x] I have provided a description and detailed information about the changes made
- [x] I have followed the [PGEcore Code Guidelines](https://github.com/PlasmoGenEpi/PGEcore?tab=readme-ov-file#code-guidelines)
- [x] I have followed the [PGEcore how to contribute instructions](https://github.com/PlasmoGenEpi/PGEcore?tab=readme-ov-file#how-to-contribute) and I am merging into the `develop` branch
- [x] Documentation is updated, if necessary
- [x] Relevant issues are linked, if applicable
