### PR TITLE
fix collapsing option handling translate loci

### DIFF
--- a/scripts/translate_loci_of_interest/translate_loci_of_interest.R
+++ b/scripts/translate_loci_of_interest/translate_loci_of_interest.R
@@ -673,7 +673,7 @@ run_translate_loci_of_interest <-function(){
     filter(aa != "X")
   
   # collapse amino acid calls 
-  allele_table_out_collapsed = collapse_allele_table(allele_table_out_filt)
+  allele_table_out_collapsed = collapse_allele_table(allele_table_out_filt, arg$collapse_calls_by_summing)
   
   
   # writing output results 


### PR DESCRIPTION
## Pull Request for PGEcore


### Description of changes
Fixed issue in translate_loci_of_interest script to pass the command line option to the function (previously had no effect)

### Pull Request Checklist

- [x] I have provided a description and detailed information about the changes made
- [x] I have followed the [PGEcore Code Guidelines](https://github.com/PlasmoGenEpi/PGEcore?tab=readme-ov-file#code-guidelines)
- [x] I have followed the [PGEcore how to contribute instructions](https://github.com/PlasmoGenEpi/PGEcore?tab=readme-ov-file#how-to-contribute) and I am merging into the `develop` branch
- [x] Documentation is updated, if necessary
- [x] Relevant issues are linked, if applicable
