### PR TITLE
Hotfix/fix specimen name handling

### DIFF
--- a/scripts/IDM_wrapper/IDM_wrapper.R
+++ b/scripts/IDM_wrapper/IDM_wrapper.R
@@ -53,10 +53,10 @@ DatImp <- function(path) {
     dat <- openxlsx::read.xlsx(path, 1)
   } else {
     if (substring(path, nchar(path) - 3, nchar(path)) == ".txt") {
-      dat <- read.table(path, header = TRUE, sep = "\t")
+      dat <- read.table(path, header = TRUE, sep = "\t", colClasses = c(specimen_name = "character"))
     } else {
       if (substring(path, nchar(path) - 3, nchar(path)) == ".csv") {
-        dat <- read.csv(path, header = TRUE, sep = ";")
+        dat <- read.csv(path, header = TRUE, sep = ";", colClasses = c(specimen_name = "character"))
       }
     }
   }
@@ -807,6 +807,7 @@ prepare_input_4_allele_table <- function(allele_table_input) {
     allele_table_input,
     col_types = cols(
       .default = col_character(),
+      specimen_name = col_character(),
       reads = col_integer()
     )
   )
@@ -855,6 +856,7 @@ prepare_input_4_aa_calls <- function(aa_calls_input) {
     aa_calls_input,
     col_types = cols(
       .default = col_character(),
+      specimen_name = col_character(),
       aa_position = col_integer()
     )
   )

--- a/scripts/MultiLociBiallelicModel_wrapper/MultiLociBiallelicModel_wrapper.R
+++ b/scripts/MultiLociBiallelicModel_wrapper/MultiLociBiallelicModel_wrapper.R
@@ -895,7 +895,7 @@ if (interactive()) {
 create_MultiLociBiallelicModel_input <- function(input_path, loci_group, aa_sample_occurence_cut_off = 0) {
   # Read the allele table
   print("Reading input data")
-  original_input_data <- read_tsv(input_path)
+  original_input_data <- read_tsv(input_path, col_types = readr::cols(specimen_name = readr::col_character()))
   
   # filter data 
   if(aa_sample_occurence_cut_off > 0){

--- a/scripts/THEREALMcCOIL_wrapper/THEREALMcCOIL_wrapper.R
+++ b/scripts/THEREALMcCOIL_wrapper/THEREALMcCOIL_wrapper.R
@@ -2315,7 +2315,10 @@ validate_data <- function(data, required_cols, data_name) {
 read_and_preprocess_snp_call <- function(snp_calls_input) {
   # read indepdent snp call table
   required_cols <- c("specimen_name", "snp_name", "reads", "seq_base")
-  df_snp_call <- read_tsv(snp_calls_input)
+  df_snp_call <- read_tsv(
+    snp_calls_input,
+    col_types = readr::cols(specimen_name = readr::col_character())
+  )
   validate_data(df_snp_call, required_cols, "SNP data")
   df_snp_call <- df_snp_call |>
     dplyr::select(all_of(required_cols))
@@ -2487,7 +2490,11 @@ call_mccoil <- function(df, args) {
 #'     \item{slaf}{A data frame with allele frequency estimates for each locus.}
 #'   }
 format_output <- function() {
-  df_mccoil <- read.table("./McCOIL_out.txt_summary.txt", sep = "\t", header = TRUE)
+  df_mccoil <- read.table(
+    "./McCOIL_out.txt_summary.txt",
+    sep = "\t", header = TRUE,
+    colClasses = c(name = "character")
+  )
 
   df_slaf <- df_mccoil %>%
     filter(CorP == "P") %>%

--- a/scripts/allele_per_locus_summary/allele_per_locus_summary.R
+++ b/scripts/allele_per_locus_summary/allele_per_locus_summary.R
@@ -66,7 +66,7 @@ arg <- parse_args(OptionParser(option_list = opts))
 create_locus_data <- function(input_path) {
 
   print("Reading input data")
-  input_data <- read.csv(input_path, na.strings = "NA", sep = "\t")
+  input_data <- read.csv(input_path, na.strings = "NA", sep = "\t", colClasses = c(specimen_name = "character"))
   locus_data <- input_data |>
     dplyr::select(specimen_name, target_name, seq) |> 
     dplyr::rename(sample_id = specimen_name, allele = seq)

--- a/scripts/coiaf_wrapper/coiaf_wrapper.R
+++ b/scripts/coiaf_wrapper/coiaf_wrapper.R
@@ -256,7 +256,7 @@ main <- function() {
   tryCatch({
     # Read SNP data
     cat("Reading SNP data...\n")
-    snp_data <- readr::read_tsv(opt$snp_data, show_col_types = FALSE)
+    snp_data <- readr::read_tsv(opt$snp_data, show_col_types = FALSE, col_types = readr::cols(specimen_name = readr::col_character()))
     validate_data(snp_data, c("specimen_name", "snp_name", "reads", "seq_base"), "SNP data")
     
     # Read PLMAF data if provided

--- a/scripts/dcifer_ibd_wrapper/dcifer_ibd_wrapper.R
+++ b/scripts/dcifer_ibd_wrapper/dcifer_ibd_wrapper.R
@@ -165,10 +165,18 @@ create_allele_table_input <- function(
                                       target_name_col = "target_name", 
                                       target_value_col = "seq") {
 
-  # Read in table
+  # Read in table. Force the specimen name column to character so that
+  # all-numeric specimen names are not inferred as numeric (which would
+  # drop leading zeros and break downstream string operations).
   allele_table <- read_tsv(
-      allele_table_path, 
-      col_types = cols(.default = col_character()), 
+      allele_table_path,
+      col_types = do.call(
+        cols,
+        c(
+          setNames(list(col_character()), specimen_name_col),
+          list(.default = col_character())
+        )
+      ),
       progress = FALSE
     ) %>%
     select(all_of(c(specimen_name_col, target_name_col, target_value_col))) %>%
@@ -221,10 +229,17 @@ create_coi_input <- function(
                              allele_list, 
                              specimen_name_col = "specimen_name") {
 
-  # Read input table
+  # Read input table. Force the specimen name column to character so that
+  # all-numeric specimen names are not inferred as numeric.
   coi <- read_tsv(
-      coi_path, 
-      col_types = cols(.default = col_character(), coi = col_integer()), 
+      coi_path,
+      col_types = do.call(
+        cols,
+        c(
+          setNames(list(col_character()), specimen_name_col),
+          list(.default = col_character(), coi = col_integer())
+        )
+      ),
       progress = FALSE
     ) %>%
     select(all_of(specimen_name_col), coi) %>%
@@ -397,10 +412,17 @@ create_specimen_metadata_input <- function(
                                       specimen_name_col = "specimen_name", 
                                       pop_name_col = "population") {
 
-  # Read in table
+  # Read in table. Force the specimen name column to character so that
+  # all-numeric specimen names are not inferred as numeric.
   specimen_metadata <- read_tsv(
-      specimen_metadata_path, 
-      col_types = cols(.default = col_character()), 
+      specimen_metadata_path,
+      col_types = do.call(
+        cols,
+        c(
+          setNames(list(col_character()), specimen_name_col),
+          list(.default = col_character())
+        )
+      ),
       progress = FALSE
     ) %>%
     select(all_of(c(specimen_name_col, pop_name_col))) %>%

--- a/scripts/dcifer_slaf_wrapper/dcifer_slaf_wrapper.R
+++ b/scripts/dcifer_slaf_wrapper/dcifer_slaf_wrapper.R
@@ -121,10 +121,18 @@ create_allele_table_input <- function(
                                       target_name_col = "target_name", 
                                       target_value_col = "seq") {
 
-  # Read in table
+  # Read in table. Force the specimen name column to character so that
+  # all-numeric specimen names are not inferred as numeric (which would
+  # drop leading zeros and break downstream string operations).
   allele_table <- read_tsv(
-      allele_table_path, 
-      col_types = cols(.default = col_character()), 
+      allele_table_path,
+      col_types = do.call(
+        cols,
+        c(
+          setNames(list(col_character()), specimen_name_col),
+          list(.default = col_character())
+        )
+      ),
       progress = FALSE
     ) %>%
     select(all_of(c(specimen_name_col, target_name_col, target_value_col))) %>%
@@ -176,10 +184,17 @@ create_coi_input <- function(
                              allele_list, 
                              specimen_name_col = "specimen_name") {
 
-  # Read input table
+  # Read input table. Force the specimen name column to character so that
+  # all-numeric specimen names are not inferred as numeric.
   coi <- read_tsv(
-      coi_path, 
-      col_types = cols(.default = col_character(), coi = col_integer()), 
+      coi_path,
+      col_types = do.call(
+        cols,
+        c(
+          setNames(list(col_character()), specimen_name_col),
+          list(.default = col_character(), coi = col_integer())
+        )
+      ),
       progress = FALSE
     ) %>%
     select(all_of(specimen_name_col), coi) %>%

--- a/scripts/estimate_coi_naive/estimate_coi_naive.R
+++ b/scripts/estimate_coi_naive/estimate_coi_naive.R
@@ -98,7 +98,7 @@ run_estimate_coi_naive <- function(input_path,
   # Read allele calls from file
   df_alleles <- read_tsv(
     input_path, 
-    col_types = cols(.default = col_character(), reads = col_integer()), 
+    col_types = cols(specimen_name = col_character(), .default = col_character(), reads = col_integer()),
     progress = FALSE
   )
   

--- a/scripts/filter_to_highest_diversity_independent_snp_call/filter_to_highest_diversity_independent_snp_call.R
+++ b/scripts/filter_to_highest_diversity_independent_snp_call/filter_to_highest_diversity_independent_snp_call.R
@@ -70,9 +70,9 @@ check_subselecting_args <- function(parsed_args){
   select_specimen_names = c()
   if("select_specimen_names" %in% names(parsed_args)){
     if(file.exists(parsed_args$select_specimen_names)){
-      select_specimen_names = readr::read_tsv(parsed_args$select_specimen_names, col_names = F)$X1
+      select_specimen_names = as.character(readr::read_tsv(parsed_args$select_specimen_names, col_names = F)$X1)
     } else { 
-      select_specimen_names = unlist(strsplit(parsed_args$select_specimen_names, split = ","))
+      select_specimen_names = as.character(unlist(strsplit(parsed_args$select_specimen_names, split = ",")))
     }
   }
   list(select_target_names = select_target_names, 
@@ -337,7 +337,7 @@ optional_sub_selections = check_subselecting_args(arg)
 warnings = c()
 
 # read in snp table for the microhaplotype data 
-snp_table_in = readr::read_tsv(arg$snp_table_in)
+snp_table_in = readr::read_tsv(arg$snp_table_in, col_types = readr::cols(specimen_name = readr::col_character()))
 
 # sanity check the input
 warnings = c(warnings, genWarningsMissCols(snp_table_in, c("specimen_name", "target_name", "chrom", "pos", "snp_name", "ref_base", "seq_base", "reads", "is_biallelic"), arg$snp_table_in))

--- a/scripts/malariaem_wrapper/malariaem_wrapper.R
+++ b/scripts/malariaem_wrapper/malariaem_wrapper.R
@@ -381,7 +381,64 @@ run_malariaem <- function(matrix, test_size, max_size, subset_targets = FALSE, t
     
     # get target names
     target_names <- colnames(matrix)
-    
+
+    # malaria.em::malaria.em() errors with "incorrect number of dimensions" when
+    # there is only a single possible haplotype. Internally it builds its design
+    # matrix with mat.or.vec(nset, nhaplo); when nhaplo == 1 this returns a plain
+    # vector rather than a matrix, and the subsequent 2-D index xmat[i, hIndex]
+    # then fails. nhaplo == 1 occurs precisely when every locus is monomorphic
+    # across the (sub)population (only one microhaplotype observed at each locus).
+    # In that case phasing is trivial: every sample is the single possible
+    # haplotype, so we build the output directly and skip malaria.em.
+    locus_allele_counts <- apply(matrix, 2, function(col){
+      alleles <- unlist(strsplit(col, "\\s+"))
+      alleles <- alleles[!is.na(alleles) & nzchar(alleles)]
+      length(unique(alleles))
+    })
+
+    if (all(locus_allele_counts == 1)) {
+      message(
+        "All loci", if (!is.null(label)) paste0(" [", label, "]"),
+        " have only a single microhaplotype across the population; there is ",
+        "only one possible haplotype. Skipping malaria.em and phasing every ",
+        "sample as the only possible haplotype."
+      )
+
+      # the single allele present at each locus
+      single_alleles <- vapply(target_names, function(tn){
+        alleles <- unlist(strsplit(matrix[, tn], "\\s+"))
+        alleles <- alleles[!is.na(alleles) & nzchar(alleles)]
+        unique(alleles)[1]
+      }, character(1))
+
+      single_hap <- tibble::tibble(
+        target_name = target_names,
+        seq = unname(single_alleles)
+      )
+
+      gt_freq_summary <- single_hap |>
+        mutate(gt_id = 1L, freq = 1, freq_se = 0) |>
+        select(gt_id, target_name, seq, freq, freq_se)
+
+      gt_phase_summary <- sample_name |>
+        select(specimen_name) |>
+        tidyr::crossing(single_hap) |>
+        mutate(gt_id = 1L, posterior_est = 1, phase_id = 1L) |>
+        select(specimen_name, target_name, seq, gt_id, posterior_est, phase_id)
+
+      if (!is.null(label)) {
+        gt_freq_summary <- gt_freq_summary |> mutate(group_id = label)
+        gt_phase_summary <- gt_phase_summary |> mutate(group_id = label)
+      }
+
+      return(list(
+        output = NULL,
+        gt_freq_summary = gt_freq_summary,
+        gt_phase_summary = gt_phase_summary,
+        group_id = label
+      ))
+    }
+
     message("Running malaria.em", if (!is.null(label)) paste0(" [", label, "]"), "...")
     output <- malaria.em::malaria.em(matrix, sizes = coi_range, locus.label = target_names)
     

--- a/scripts/malariaem_wrapper/malariaem_wrapper.R
+++ b/scripts/malariaem_wrapper/malariaem_wrapper.R
@@ -454,7 +454,9 @@ run_malariaem <- function(matrix, test_size, max_size, subset_targets = FALSE, t
              target_name = hap_id, 
              seq, 
              freq = hap.prob, 
-             freq_se = hap.prob.std)
+             freq_se = hap.prob.std)  |>
+      mutate(freq = as.numeric(freq), 
+             freq_se = as.numeric(freq_se))
     
     if (!is.null(label)) {
       gt_freq_summary <- gt_freq_summary |> mutate(group_id = label)

--- a/scripts/moire_wrapper/moire_wrapper.R
+++ b/scripts/moire_wrapper/moire_wrapper.R
@@ -330,7 +330,7 @@ create_moire_input <- function(input_path, allow_relatedness, burnin,
                                pt_chains, pt_grad_lower,
                                pt_num_threads, adapt_temp, max_runtime) {
   print("Reading input data")
-  input_data <- read.csv(input_path, na.strings = "NA", sep = "\t")
+  input_data <- read.csv(input_path, na.strings = "NA", sep = "\t", colClasses = c(specimen_name = "character"))
   
   # check for require columns 
   miss_cols = get_missing_columns(input_data, c("specimen_name", "target_name", "seq"))

--- a/scripts/multilocus_prevfreq_naive/multilocus_prevfreq_naive.R
+++ b/scripts/multilocus_prevfreq_naive/multilocus_prevfreq_naive.R
@@ -109,10 +109,10 @@ create_aa_table_input <- function(aa_table) {
   stopifnot(is.character(aa_table))
   
   # read in amino acid calls and validate columns
-  df_aa <- read.table(aa_table, header = TRUE)
+  df_aa <- read.table(aa_table, header = TRUE, colClasses = c(specimen_name = "character"))
   rules <- validate::validator(
-    is.character(specimen_name), 
-    is.character(gene), 
+    is.character(specimen_name),
+    is.character(gene),
     is.character(gene_id),
     is.integer(aa_position), 
     is.integer(reads), 

--- a/scripts/multilocus_prevfreq_naive_variantstring/multilocus_prevfreq_naive_variantstring.R
+++ b/scripts/multilocus_prevfreq_naive_variantstring/multilocus_prevfreq_naive_variantstring.R
@@ -70,10 +70,10 @@ create_aa_table_input <- function(aa_table) {
   stopifnot(is.character(aa_table))
   
   # read in amino acid calls and validate columns
-  df_aa <- read.table(aa_table, header = TRUE)
+  df_aa <- read.table(aa_table, header = TRUE, colClasses = c(specimen_name = "character"))
   rules <- validate::validator(
-    is.character(specimen_name), 
-    is.character(gene_id), 
+    is.character(specimen_name),
+    is.character(gene_id),
     is.integer(aa_position), 
     is.integer(reads), 
     is.character(aa), 

--- a/scripts/pileup_specific_snps/pileup_specific_snps.R
+++ b/scripts/pileup_specific_snps/pileup_specific_snps.R
@@ -164,9 +164,9 @@ check_subselecting_args <- function(parsed_args){
   select_specimen_names = c()
   if("select_specimen_names" %in% names(parsed_args)){
     if(file.exists(parsed_args$select_specimen_names)){
-      select_specimen_names = readr::read_tsv(parsed_args$select_specimen_names, col_names = F)$X1
-    } else { 
-      select_specimen_names = unlist(strsplit(parsed_args$select_specimen_names, split = ","))
+      select_specimen_names = as.character(readr::read_tsv(parsed_args$select_specimen_names, col_names = F)$X1)
+    } else {
+      select_specimen_names = as.character(unlist(strsplit(parsed_args$select_specimen_names, split = ",")))
     }
   }
   list(select_target_names = select_target_names, 
@@ -578,8 +578,8 @@ run_pileup_specific_snps <-function(){
   snps_of_interest = readr::read_tsv(arg$snps_of_interest, col_names = T)
   warnings = c(warnings, genWarningsMissCols(snps_of_interest, c("#chrom", "start", "end", "name", "length", "strand"), arg$snps_of_interest))
   
-  # read in allele table for the microhaplotype data 
-  allele_table = readr::read_tsv(arg$allele_table)
+  # read in allele table for the microhaplotype data
+  allele_table = readr::read_tsv(arg$allele_table, col_types = readr::cols(specimen_name = readr::col_character()))
   warnings = c(warnings, genWarningsMissCols(allele_table, c("specimen_name","target_name","reads","seq"), arg$allele_table))
   if(length(warnings) > 0){
     stop(paste0("\n", paste0(warnings, collapse = "\n")) )

--- a/scripts/snp_calls_to_vcf/snp_calls_to_vcf.R
+++ b/scripts/snp_calls_to_vcf/snp_calls_to_vcf.R
@@ -112,7 +112,7 @@ run_snp_calls_to_vcf <- function(){
     stop(paste0(arg$vcf_output, " already exists, use --overwrite to overwrite"))
   }
 
-  calls <- readr::read_tsv(arg$snp_calls)
+  calls <- readr::read_tsv(arg$snp_calls, col_types = readr::cols(specimen_name = readr::col_character()))
   needed <- c("specimen_name", "chrom", "pos", "snp_name", "strand", "ref_base", "seq_base", "reads")
   miss <- returnMissingColumns(calls, needed)
   if(length(miss) > 0){

--- a/scripts/translate_loci_of_interest/translate_loci_of_interest.R
+++ b/scripts/translate_loci_of_interest/translate_loci_of_interest.R
@@ -165,9 +165,9 @@ check_subselecting_args <- function(parsed_args){
   select_specimen_names = c()
   if("select_specimen_names" %in% names(parsed_args)){
     if(file.exists(parsed_args$select_specimen_names)){
-      select_specimen_names = readr::read_tsv(parsed_args$select_specimen_names, col_names = F)$X1
-    } else { 
-      select_specimen_names = unlist(strsplit(parsed_args$select_specimen_names, split = ","))
+      select_specimen_names = as.character(readr::read_tsv(parsed_args$select_specimen_names, col_names = F)$X1)
+    } else {
+      select_specimen_names = as.character(unlist(strsplit(parsed_args$select_specimen_names, split = ",")))
     }
   }
   list(select_target_names = select_target_names, 
@@ -487,7 +487,7 @@ validate_columns_types <-function(ref_bed, loci_of_interest, allele_table){
   
   # validate columns allele_table
   allele_table_rules <- validate::validator(
-    is.character(specimen_name) | is.numeric(specimen_name),
+    is.character(specimen_name),
     is.numeric(reads),
     is.character(target_name), 
     is.character(seq),
@@ -606,8 +606,8 @@ run_translate_loci_of_interest <-function(){
   loci_of_interest = readr::read_tsv(arg$loci_of_interest, col_names = T)
   warnings = c(warnings, genWarningsMissCols(loci_of_interest, c("#chrom", "start", "end", "name", "length", "strand", "gene", "gene_id", "aa_position"), arg$loci_of_interest))
   
-  # read in allele table for the microhaplotype data 
-  allele_table = readr::read_tsv(arg$allele_table)
+  # read in allele table for the microhaplotype data
+  allele_table = readr::read_tsv(arg$allele_table, col_types = readr::cols(specimen_name = readr::col_character()))
   warnings = c(warnings, genWarningsMissCols(allele_table, c("specimen_name","target_name","reads","seq"), arg$allele_table))
   warnings = c(warnings, check_warnings_for_subselecting_allele_table(allele_table, optional_sub_selections, arg$allele_table))
   

--- a/scripts/translate_loci_of_interest/translate_loci_of_interest.R
+++ b/scripts/translate_loci_of_interest/translate_loci_of_interest.R
@@ -487,7 +487,7 @@ validate_columns_types <-function(ref_bed, loci_of_interest, allele_table){
   
   # validate columns allele_table
   allele_table_rules <- validate::validator(
-    is.character(specimen_name),
+    is.character(specimen_name) | is.numeric(specimen_name),
     is.numeric(reads),
     is.character(target_name), 
     is.character(seq),

--- a/scripts/vcf_to_snp_calls/vcf_to_snp_calls.R
+++ b/scripts/vcf_to_snp_calls/vcf_to_snp_calls.R
@@ -93,7 +93,7 @@ run_vcf_to_snp_calls <- function(){
   if(length(header) < 10){
     stop("VCF has no sample columns; nothing to emit (need FORMAT + at least one sample)")
   }
-  samples <- header[10:length(header)]
+  samples <- as.character(header[10:length(header)])
 
   data_lines <- lines[(header_idx[1] + 1):length(lines)]
   data_lines <- data_lines[nzchar(data_lines)]


### PR DESCRIPTION
## Pull Request for PGEcore


### Description of changes

If the specimen_name column appears like numerical values (e.g., sample names are 1,2,3,4,5), then scripts fail due to validating for specimen_name to be a character, and some scripts fail cause it tries to subscript with the specimen_name, but will get errors cause they are being treated as numbers rather than characters. Now I put in the enforcement for reading in the specimen_name column as characters rather than be auto-detected, this will also help to protect against instances where names could be barcode-like and if they had leading 0's they would be stripped if treated as numerical rather than character 

### Pull Request Checklist

- [x] I have provided a description and detailed information about the changes made
- [x] I have followed the [PGEcore Code Guidelines](https://github.com/PlasmoGenEpi/PGEcore?tab=readme-ov-file#code-guidelines)
- [x] I have followed the [PGEcore how to contribute instructions](https://github.com/PlasmoGenEpi/PGEcore?tab=readme-ov-file#how-to-contribute) and I am merging into the `develop` branch
- [x] Documentation is updated, if necessary
- [x] Relevant issues are linked, if applicable
